### PR TITLE
Bump to GHC 8.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .cabal-sandbox
 cabal.*
+
+# Haskell Tool Stack-related
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.1"
+    - compiler: "ghc-8.4.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.3], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/servant-JuicyPixels.cabal
+++ b/servant-JuicyPixels.cabal
@@ -10,7 +10,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 synopsis:            Servant support for JuicyPixels
 description:         Provides content types for image types supported by JuicyPixels
-tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.1
+tested-with:         GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.3
 
 source-repository HEAD
   type: git

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-8.22
+resolver: nightly-2018-06-26
 packages:
 - '.'


### PR DESCRIPTION
Also adds the Haskell Tool Stack's artefacts to .gitignore.

Could a GHC 8.4.3-capable version be released to Hackage/Stackage?